### PR TITLE
Process header based HMAC token and secure compare

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,18 +21,18 @@ module.exports = function (algorithm, key, token, opts) {
 		if (!(header && request.headers[header]) && !request.query[token]) return response.sendStatus(401)
 
 		var receivedHmac = crypto.createHmac(algorithm, key)
-    if (header && request.headers[header]) {
+		if (header && request.headers[header]) {
 			receivedHmac.update(request.headers[header])
 		} else {
-      receivedHmac.update(request.query[token])
-    }
+			receivedHmac.update(request.query[token])
+		}
 		var computedHmac = crypto.createHmac(algorithm, key)
 		computedHmac.update(hmac.digest(encoding))
 
-		if (bufferEq(new Buffer(receivedHmac.digest(encoding)), new Buffer(computedHmac.digest(encoding))) {
-      next()
-    } else {
-      return response.sendStatus(401)
-    }
+		if (bufferEq(new Buffer(receivedHmac.digest(encoding)), new Buffer(computedHmac.digest(encoding)))) {
+			next()
+		} else {
+			return response.sendStatus(401)
+		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "homepage": "https://github.com/AsoSunag/hmac-express",
   "dependencies": {
+    "buffer-equal-constant-time": "^1.0.1",
     "mocha": "^2.4.5"
   },
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -78,10 +78,10 @@ describe("hmac-express", function() {
 		})
 	})
 
-  it("should pass with an empty JSON body with header token", function(done) {
-    var opts = {
-        header: "HMAC"
-    }
+	it("should pass with an empty JSON body with header token", function(done) {
+		var opts = {
+			header: "HMAC"
+		}
 		var middleware = hmacExpress("sha256", "secret", "token", opts)
 		var hmac = crypto.createHmac("sha256", "secret")
 		var body = {}
@@ -104,9 +104,9 @@ describe("hmac-express", function() {
 	})
 
 	it("should pass with a JSON body with header token", function(done) {
-    var opts = {
-        header: "HMAC"
-    }
+		var opts = {
+			header: "HMAC"
+		}
 		var middleware = hmacExpress("sha256", "secret", "token", opts)
 		var hmac = crypto.createHmac("sha256", "secret")
 		var body = {
@@ -134,10 +134,10 @@ describe("hmac-express", function() {
 	})
 
 	it("should not pass if the hmac of the received body is different with header token", function(done) {
-    var opts = {
-        header: "HMAC"
-    }
-    var middleware = hmacExpress("sha256", "secret", "token", opts)
+		var opts = {
+			header: "HMAC"
+		}
+		var middleware = hmacExpress("sha256", "secret", "token", opts)
 		var body = {
 			"key1": "value1",
 			"Key2": {
@@ -166,11 +166,11 @@ describe("hmac-express", function() {
 	it("should pass with the header version and a different encoding", function(done) {
 		var opts = {
 			encoding: "base64",
-    		header: "HMAC"
+				header: "HMAC"
 		}
 		var middleware = hmacExpress("sha256", "secret", "token", opts)
 		var hmac = crypto.createHmac("sha256", "secret")
-    var body = {
+		var body = {
 			"key1": "value1",
 			"Key2": {
 				"key21": "value21",
@@ -180,8 +180,8 @@ describe("hmac-express", function() {
 		hmac.update(JSON.stringify(body))
 
 		var request = {
-      "body": body,
-      "headers": {
+			"body": body,
+			"headers": {
 				"HMAC": hmac.digest("base64")
 			}
 		}

--- a/test/test.js
+++ b/test/test.js
@@ -78,22 +78,20 @@ describe("hmac-express", function() {
 		})
 	})
 
-	it("should pass with the header version and a different encoding", function(done) {
-		var opts = {
-			encoding: "base64",
-    		header: "timestamp"
-		}
+  it("should pass with an empty JSON body with header token", function(done) {
+    var opts = {
+        header: "HMAC"
+    }
 		var middleware = hmacExpress("sha256", "secret", "token", opts)
 		var hmac = crypto.createHmac("sha256", "secret")
+		var body = {}
 
-		hmac.update("12345T")
+		hmac.update(JSON.stringify(body))
 
 		var request = {
-			"query": {
-				"token": hmac.digest("base64")
-			},
+			"body": body,
 			"headers": {
-				"timestamp": "12345T"
+				"HMAC": hmac.digest("hex")
 			}
 		}
 
@@ -105,18 +103,53 @@ describe("hmac-express", function() {
 		return middleware(request, response, done)
 	})
 
-	it("should not pass if the hmac of the received header is different", function(done) {
-		var opts = {
-    		header: "timestamp"
-		}
+	it("should pass with a JSON body with header token", function(done) {
+    var opts = {
+        header: "HMAC"
+    }
 		var middleware = hmacExpress("sha256", "secret", "token", opts)
+		var hmac = crypto.createHmac("sha256", "secret")
+		var body = {
+			"key1": "value1",
+			"Key2": {
+				"key21": "value21",
+				"key22": "value22",
+			}
+		}
+		hmac.update(JSON.stringify(body))
 
 		var request = {
-			"query": {
-				"token": "wronghmac"
-			},
+			"body": body,
 			"headers": {
-				"timestamp": "12345T"
+				"HMAC": hmac.digest("hex")
+			}
+		}
+
+		var response = {
+			sendStatus: function(code) {
+				return done(new Error("Fail with the wrong error code"))
+			}
+		}
+		return middleware(request, response, done)
+	})
+
+	it("should not pass if the hmac of the received body is different with header token", function(done) {
+    var opts = {
+        header: "HMAC"
+    }
+    var middleware = hmacExpress("sha256", "secret", "token", opts)
+		var body = {
+			"key1": "value1",
+			"Key2": {
+				"key21": "value21",
+				"key22": "value22",
+			}
+		}
+
+		var request = {
+			"body": body,
+			"headers": {
+				"HMAC": "wronghmac"
 			}
 		}
 
@@ -130,4 +163,34 @@ describe("hmac-express", function() {
 		})
 	})
 
+	it("should pass with the header version and a different encoding", function(done) {
+		var opts = {
+			encoding: "base64",
+    		header: "HMAC"
+		}
+		var middleware = hmacExpress("sha256", "secret", "token", opts)
+		var hmac = crypto.createHmac("sha256", "secret")
+    var body = {
+			"key1": "value1",
+			"Key2": {
+				"key21": "value21",
+				"key22": "value22",
+			}
+		}
+		hmac.update(JSON.stringify(body))
+
+		var request = {
+      "body": body,
+      "headers": {
+				"HMAC": hmac.digest("base64")
+			}
+		}
+
+		var response = {
+			sendStatus: function(code) {
+				return done(new Error("Fail with the wrong error code"))
+			}
+		}
+		return middleware(request, response, done)
+	})
 })


### PR DESCRIPTION
Utilize constant-time equality to prevent timing attacks through
buffer-equal-constant-time

HMAC is intended to authenticate request bodies and not request
headers.  This update correctly implements HMAC for cases where
the HMAC digest is submitted via headers, ie gitHub webhooks where
HMAC is passed as HTTP_X_HUB_SIGNATURE.

Should resolve #1 and #2
