### PR TITLE
Moved mocha to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   ],
   "homepage": "https://github.com/AsoSunag/hmac-express",
   "dependencies": {
-    "buffer-equal-constant-time": "^1.0.1",
+    "buffer-equal-constant-time": "^1.0.1"
+  },
+  "devDependencies": {
     "mocha": "^2.4.5"
   },
   "scripts": {


### PR DESCRIPTION
`mocha` is not required for the module to work, therefore should be a dev dependency.